### PR TITLE
Resource importing support

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,45 @@
+# Provider Eng Documentation
+
+This document provides detailed information about the advanced usage of Edge Delta provider.
+
+## Imports
+
+Terraform CLI offers functionality to import the existing resources to your tfstate and resource definition file, to prevent deleting and re-creating the remote resource to be able to define and manage the same resource on local.
+
+Currently `edgedelta_config` and `edgedelta_monitor` resources support importing. To import your resources, please follow the instructions below:
+
+#### Get resource ID
+
+1. Go to [app.edgedelta.com](https://app.edgedelta.com) and log in to your account
+2. Go to the page of the specific resource that you want to import
+   1. For `edgedelta_config`, go to Agent Settings under Data Pipeline
+   2. For `edgedelta_monitor`, go to Monitors under Management
+3. Find the ID of the specific resource you want to import
+   1. For `edgedelta_config`, the IDs are listed under the "Key" column
+   2. For `edgedelta_monitor`, open the developer tools and go to network tab for Chrome (or the equivalent one for any browser)
+   3. Refresh the page and find the xhr request with name `alert_definitions`
+   4. Inspect the response and find the `id` of the specific monitor you want to import
+
+#### Create the resource definition
+
+1. Create a skeleton resource definition in your `.tf` file. An example resoruce skeleton can be found below:
+
+```hcl
+resource "edgedelta_config" "imported_config" {
+
+}
+```
+
+2. Run `terraform import` with the name of the skeleton resource you have just created and the resource ID you have from the previous steps:
+
+```bash
+terraform import edgedelta_config.imported_config <resource-id>
+```
+
+3. If you have done the previous steps correctly, terraform will fetch the resource data from Edge Delta and store it in the `.tfstate` file. You should be able to see the resource data in your terraform state now. Feel free to check your state file to make sure `terraform import` ran correctly.
+
+#### Sync the resource definition
+
+1. Run `terraform show` in your terminal. This command will show the data of your resources in the current state file in the hcl format.
+2. Copy the resource definition you have imported recently from the output of the previous command, and use it to fill up the resource skeleton.
+3. Run `terraform apply` to see that there is no diff between the resource in the state and the one in the `.tf` file.

--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -57,6 +57,22 @@ resource "edgedelta_config" "config_with_id" {
 }
 ```
 
+## Importing Existing Configs
+
+You can import your existing config resources to the terraform state using `terraform import` command with a specific config ID. 
+
+- Define a config resource
+```hcl
+resource "edgedelta_config" "imported_config" {
+
+}
+```
+
+- Run `terraform import` on terminal
+```bash
+terraform import edgedelta_config.imported_config <resource-id>
+```
+
 ## Schema
 
 | Name           | Description                                                                                                                             | Type   | Default | Required |

--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -73,6 +73,8 @@ resource "edgedelta_config" "imported_config" {
 terraform import edgedelta_config.imported_config <resource-id>
 ```
 
+More detailed information about resource imports can be found in [advanced docs](../advanced.md).
+
 ## Schema
 
 | Name           | Description                                                                                                                             | Type   | Default | Required |

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -67,6 +67,8 @@ resource "edgedelta_monitor" "imported_monitor" {
 terraform import edgedelta_monitor.imported_monitor <resource-id>
 ```
 
+More detailed information about resource imports can be found in [advanced docs](../advanced.md).
+
 ## Schema
 
 |Name|Description|Type|Default|Required|

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -51,6 +51,22 @@ resource "edgedelta_monitor" "existing_monitor" {
 }
 ```
 
+## Importing Existing Monitors
+
+You can import your existing monitor resources to the terraform state using `terraform import` command with a specific monitor ID. 
+
+- Define a monitor resource
+```hcl
+resource "edgedelta_monitor" "imported_monitor" {
+
+}
+```
+
+- Run `terraform import` on terminal
+```bash
+terraform import edgedelta_monitor.imported_monitor <resource-id>
+```
+
 ## Schema
 
 |Name|Description|Type|Default|Required|

--- a/edgedelta/api_client.go
+++ b/edgedelta/api_client.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -30,7 +31,7 @@ func (cli *APIClient) initializeHTTPClient() {
 	}
 }
 
-func (cli *APIClient) doRequest(entityName string, entityID string, method string, checkOKResp bool, bodyObj interface{}) ([]byte, int, error) {
+func (cli *APIClient) doRequest(entityName string, entityID string, method string, checkOKResp bool, checkNilBody bool, bodyObj interface{}) ([]byte, int, error) {
 	var baseURL *url.URL
 	var err error
 
@@ -68,12 +69,16 @@ func (cli *APIClient) doRequest(entityName string, entityID string, method strin
 	if checkOKResp && (200 > resp.StatusCode || resp.StatusCode > 299) {
 		return nil, 0, fmt.Errorf("got non OK http status from: %s, status: %v, response: %q", req.URL.RequestURI(), resp.StatusCode, string(body))
 	}
+	if checkNilBody && (strings.TrimSpace(string(body)) == "null") {
+		return nil, 0, fmt.Errorf("API returned null response body from: %s, status: %v, response: %q", req.URL.RequestURI(), resp.StatusCode, string(body))
+
+	}
 	return body, resp.StatusCode, nil
 }
 
 func (cli *APIClient) GetConfigWithID(configID string) (*GetConfigResponse, error) {
 	cli.initializeHTTPClient()
-	b, _, err := cli.doRequest("confs", configID, http.MethodGet, true, nil)
+	b, _, err := cli.doRequest("confs", configID, http.MethodGet, true, true, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +91,7 @@ func (cli *APIClient) GetConfigWithID(configID string) (*GetConfigResponse, erro
 
 func (cli *APIClient) CreateConfig(configObject Config) (*CreateConfigResponse, error) {
 	cli.initializeHTTPClient()
-	b, _, err := cli.doRequest("confs", "", http.MethodPost, true, configObject)
+	b, _, err := cli.doRequest("confs", "", http.MethodPost, true, true, configObject)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +104,7 @@ func (cli *APIClient) CreateConfig(configObject Config) (*CreateConfigResponse, 
 
 func (cli *APIClient) UpdateConfigWithID(configID string, configObject Config) (*UpdateConfigResponse, error) {
 	cli.initializeHTTPClient()
-	b, _, err := cli.doRequest("confs", configID, http.MethodPut, true, configObject)
+	b, _, err := cli.doRequest("confs", configID, http.MethodPut, true, true, configObject)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +117,7 @@ func (cli *APIClient) UpdateConfigWithID(configID string, configObject Config) (
 
 func (cli *APIClient) GetMonitorWithID(monitorID string) (*GetMonitorResponse, error) {
 	cli.initializeHTTPClient()
-	b, _, err := cli.doRequest("alert_definitions", monitorID, http.MethodGet, true, nil)
+	b, _, err := cli.doRequest("alert_definitions", monitorID, http.MethodGet, true, true, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +130,7 @@ func (cli *APIClient) GetMonitorWithID(monitorID string) (*GetMonitorResponse, e
 
 func (cli *APIClient) CreateMonitor(monitor Monitor) (*CreateMonitorResponse, error) {
 	cli.initializeHTTPClient()
-	b, _, err := cli.doRequest("alert_definitions", "", http.MethodPost, true, monitor)
+	b, _, err := cli.doRequest("alert_definitions", "", http.MethodPost, true, true, monitor)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +143,7 @@ func (cli *APIClient) CreateMonitor(monitor Monitor) (*CreateMonitorResponse, er
 
 func (cli *APIClient) UpdateMonitorWithID(monitorID string, monitor Monitor) (*UpdateMonitorResponse, error) {
 	cli.initializeHTTPClient()
-	b, _, err := cli.doRequest("alert_definitions", monitorID, http.MethodPut, true, monitor)
+	b, _, err := cli.doRequest("alert_definitions", monitorID, http.MethodPut, true, true, monitor)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +156,7 @@ func (cli *APIClient) UpdateMonitorWithID(monitorID string, monitor Monitor) (*U
 
 func (cli *APIClient) DeleteMonitorWithID(monitorID string) error {
 	cli.initializeHTTPClient()
-	_, _, err := cli.doRequest("alert_definitions", monitorID, http.MethodDelete, true, nil)
+	_, _, err := cli.doRequest("alert_definitions", monitorID, http.MethodDelete, true, true, nil)
 	if err != nil {
 		return err
 	}

--- a/edgedelta/resources_config.go
+++ b/edgedelta/resources_config.go
@@ -38,9 +38,12 @@ func resourceConfig() *schema.Resource {
 			State: func(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 				meta := m.(*ProviderMetadata)
 				confID := d.Id()
+				if confID == "" { // confID DNE
+					return nil, fmt.Errorf("Could not determine the resource ID - possibly the ID was not set")
+				}
 				resp, err := meta.client.GetConfigWithID(confID)
 				if err != nil {
-					return nil, fmt.Errorf("Could not get the resource data from API: %s", err)
+					return nil, fmt.Errorf("Could not get the resource data from API: %s (resource ID was: '%s')", err, confID)
 				}
 				d.SetId(resp.ID)
 				d.Set("conf_id", confID)

--- a/edgedelta/resources_config.go
+++ b/edgedelta/resources_config.go
@@ -34,6 +34,21 @@ func resourceConfig() *schema.Resource {
 				Computed: true,
 			},
 		},
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+				meta := m.(*ProviderMetadata)
+				confID := d.Id()
+				resp, err := meta.client.GetConfigWithID(confID)
+				if err != nil {
+					return nil, fmt.Errorf("Could not get the resource data from API: %s", err)
+				}
+				d.SetId(resp.ID)
+				d.Set("conf_id", confID)
+				d.Set("org_id", resp.OrgID)
+				d.Set("tag", resp.Tag)
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 	}
 }
 

--- a/edgedelta/resources_monitor.go
+++ b/edgedelta/resources_monitor.go
@@ -68,6 +68,25 @@ func resourceMonitor() *schema.Resource {
 				Description: "Unique monitor ID",
 			},
 		},
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+				meta := m.(*ProviderMetadata)
+				monitorID := d.Id()
+				resp, err := meta.client.GetMonitorWithID(monitorID)
+				if err != nil {
+					return nil, fmt.Errorf("Could not get the resource data from API: %s", err)
+				}
+				d.SetId(resp.ID)
+				d.Set("monitor_id", monitorID)
+				d.Set("org_id", resp.OrgID)
+				d.Set("name", resp.Name)
+				d.Set("type", resp.Type)
+				d.Set("enabled", resp.Enabled)
+				d.Set("payload", resp.Payload)
+				d.Set("creator", resp.Creator)
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 	}
 }
 

--- a/edgedelta/resources_monitor.go
+++ b/edgedelta/resources_monitor.go
@@ -72,9 +72,12 @@ func resourceMonitor() *schema.Resource {
 			State: func(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 				meta := m.(*ProviderMetadata)
 				monitorID := d.Id()
+				if monitorID == "" { // monitorID DNE
+					return nil, fmt.Errorf("Could not determine the resource ID - possibly the ID was not set")
+				}
 				resp, err := meta.client.GetMonitorWithID(monitorID)
 				if err != nil {
-					return nil, fmt.Errorf("Could not get the resource data from API: %s", err)
+					return nil, fmt.Errorf("Could not get the resource data from API: %s (resource ID was: '%s')", err, monitorID)
 				}
 				d.SetId(resp.ID)
 				d.Set("monitor_id", monitorID)


### PR DESCRIPTION
## Summary

To support the `terraform import` command to import the existing resources (configs and monitors for the time being), the importer functions are needed to be implemented.

## Testing

To test the importing functionality, basically create an empty resource definition in a `.tf` file (such as the example below), and run the command below with the ID of an existing resource.

Example terraform config:
```hcl
resource "edgedelta_config" "imported_conf" {}
```

Command to import the existing resource:
```bash
terraform import edgedelta_config.imported_conf <existing-resource-ID-here>
```