### PR TITLE
Validate resource IDs in API client to prevent traversal attacks

### DIFF
--- a/edgedelta/api_client.go
+++ b/edgedelta/api_client.go
@@ -10,7 +10,14 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
+
+func validateUUID(val string) bool {
+	_, err := uuid.Parse(val)
+	return err == nil
+}
 
 type APIClient struct {
 	OrgID      string
@@ -77,6 +84,9 @@ func (cli *APIClient) doRequest(entityName string, entityID string, method strin
 }
 
 func (cli *APIClient) GetConfigWithID(configID string) (*GetConfigResponse, error) {
+	if ok := validateUUID(configID); !ok {
+		return nil, fmt.Errorf("failed to validate the config ID: '%s'", configID)
+	}
 	cli.initializeHTTPClient()
 	b, _, err := cli.doRequest("confs", configID, http.MethodGet, true, true, nil)
 	if err != nil {
@@ -103,6 +113,9 @@ func (cli *APIClient) CreateConfig(configObject Config) (*CreateConfigResponse, 
 }
 
 func (cli *APIClient) UpdateConfigWithID(configID string, configObject Config) (*UpdateConfigResponse, error) {
+	if ok := validateUUID(configID); !ok {
+		return nil, fmt.Errorf("failed to validate the config ID: '%s'", configID)
+	}
 	cli.initializeHTTPClient()
 	b, _, err := cli.doRequest("confs", configID, http.MethodPut, true, true, configObject)
 	if err != nil {
@@ -116,6 +129,9 @@ func (cli *APIClient) UpdateConfigWithID(configID string, configObject Config) (
 }
 
 func (cli *APIClient) GetMonitorWithID(monitorID string) (*GetMonitorResponse, error) {
+	if ok := validateUUID(monitorID); !ok {
+		return nil, fmt.Errorf("failed to validate the monitor ID: '%s'", monitorID)
+	}
 	cli.initializeHTTPClient()
 	b, _, err := cli.doRequest("alert_definitions", monitorID, http.MethodGet, true, true, nil)
 	if err != nil {
@@ -142,6 +158,9 @@ func (cli *APIClient) CreateMonitor(monitor Monitor) (*CreateMonitorResponse, er
 }
 
 func (cli *APIClient) UpdateMonitorWithID(monitorID string, monitor Monitor) (*UpdateMonitorResponse, error) {
+	if ok := validateUUID(monitorID); !ok {
+		return nil, fmt.Errorf("failed to validate the monitor ID: '%s'", monitorID)
+	}
 	cli.initializeHTTPClient()
 	b, _, err := cli.doRequest("alert_definitions", monitorID, http.MethodPut, true, true, monitor)
 	if err != nil {
@@ -155,6 +174,9 @@ func (cli *APIClient) UpdateMonitorWithID(monitorID string, monitor Monitor) (*U
 }
 
 func (cli *APIClient) DeleteMonitorWithID(monitorID string) error {
+	if ok := validateUUID(monitorID); !ok {
+		return fmt.Errorf("failed to validate the monitor ID: '%s'", monitorID)
+	}
 	cli.initializeHTTPClient()
 	_, _, err := cli.doRequest("alert_definitions", monitorID, http.MethodDelete, true, true, nil)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,42 @@ module terraform-provider-edgedelta
 
 go 1.17
 
-require github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.1
+require (
+	github.com/google/uuid v1.1.2
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.1
+)
+
+require (
+	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/apparentlymart/go-textseg v1.0.0 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
+	github.com/hashicorp/go-hclog v0.15.0 // indirect
+	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/hashicorp/go-plugin v1.4.1 // indirect
+	github.com/hashicorp/go-uuid v1.0.1 // indirect
+	github.com/hashicorp/go-version v1.3.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.3.0 // indirect
+	github.com/hashicorp/terraform-plugin-go v0.3.0 // indirect
+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/go-isatty v0.0.10 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.0.4 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/oklog/run v1.0.0 // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
+	github.com/zclconf/go-cty v1.8.4 // indirect
+	golang.org/x/net v0.0.0-20210326060303-6b1517762897 // indirect
+	golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect
+	google.golang.org/grpc v1.32.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,7 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=


### PR DESCRIPTION
## Summary
The provider allows users to input config and monitor IDs to run `terraform import` (ex: `terraform import edgedelta_config.foobar_config "11111111-1111-1111-1111-111111111111"`). Currently, not the importer functions nor the API client functions do proper input sanitization and validation, so the user can give strings such as `"../../"` for the resource ID. This later constructs a URI for the API call prone to a path traversal attack such as `"/v1/orgs/11111111-1111-1111-1111-111111111111/confs/../../"`.

Fixes #[2793](https://edgedelta.atlassian.net/browse/ED-2793)
