### PR TITLE
Support bulk resource importing for edgedelta_config and edgedelta_monitor resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ build:
 	go build -o ${BINARY}
 
 install: build
-	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${VERSION}/${OS_ARCH}
-	cp ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${VERSION}/${OS_ARCH}
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+	cp ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ${GOPATH}/bin
 
 release:

--- a/edgedelta/api_client.go
+++ b/edgedelta/api_client.go
@@ -67,7 +67,7 @@ func (cli *APIClient) doRequest(entityName string, entityID string, method strin
 		return nil, 0, fmt.Errorf("failed to read response body from '%s'. err: %v", req.URL.RequestURI(), err)
 	}
 	if checkOKResp && (200 > resp.StatusCode || resp.StatusCode > 299) {
-		return nil, 0, fmt.Errorf("got non OK http status from: %s, status: %v, response: %q", req.URL.RequestURI(), resp.StatusCode, string(body))
+		return nil, 0, fmt.Errorf("got non OK http status from: %s %s, status: %v, response: %q", req.Method, req.URL.RequestURI(), resp.StatusCode, string(body))
 	}
 	if checkNilBody && (strings.TrimSpace(string(body)) == "null") {
 		return nil, 0, fmt.Errorf("API returned null response body from: %s, status: %v, response: %q", req.URL.RequestURI(), resp.StatusCode, string(body))
@@ -87,6 +87,19 @@ func (cli *APIClient) GetConfigWithID(configID string) (*GetConfigResponse, erro
 		return nil, fmt.Errorf("failed to unmarshal the response body: %s", err)
 	}
 	return &responseData, nil
+}
+
+func (cli *APIClient) GetAllConfigs() ([]*Config, error) {
+	cli.initializeHTTPClient()
+	b, _, err := cli.doRequest("confs", "", http.MethodGet, true, true, nil)
+	if err != nil {
+		return nil, err
+	}
+	var responseData []*Config
+	if err := json.Unmarshal(b, &responseData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the response body: %s", err)
+	}
+	return responseData, nil
 }
 
 func (cli *APIClient) CreateConfig(configObject Config) (*CreateConfigResponse, error) {
@@ -126,6 +139,19 @@ func (cli *APIClient) GetMonitorWithID(monitorID string) (*GetMonitorResponse, e
 		return nil, fmt.Errorf("failed to unmarshal the response body: %s", err)
 	}
 	return &responseData, nil
+}
+
+func (cli *APIClient) GetAllMonitors() ([]*Monitor, error) {
+	cli.initializeHTTPClient()
+	b, _, err := cli.doRequest("alert_definitions", "", http.MethodGet, true, true, nil)
+	if err != nil {
+		return nil, err
+	}
+	var responseData []*Monitor
+	if err := json.Unmarshal(b, &responseData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the response body: %s", err)
+	}
+	return responseData, nil
 }
 
 func (cli *APIClient) CreateMonitor(monitor Monitor) (*CreateMonitorResponse, error) {

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,38 @@ module terraform-provider-edgedelta
 go 1.17
 
 require github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.1
+
+require (
+	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/apparentlymart/go-textseg v1.0.0 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
+	github.com/hashicorp/go-hclog v0.15.0 // indirect
+	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/hashicorp/go-plugin v1.4.1 // indirect
+	github.com/hashicorp/go-uuid v1.0.1 // indirect
+	github.com/hashicorp/go-version v1.3.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.3.0 // indirect
+	github.com/hashicorp/terraform-plugin-go v0.3.0 // indirect
+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/go-isatty v0.0.10 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.0.4 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/oklog/run v1.0.0 // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
+	github.com/zclconf/go-cty v1.8.4 // indirect
+	golang.org/x/net v0.0.0-20210326060303-6b1517762897 // indirect
+	golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect
+	google.golang.org/grpc v1.32.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+)


### PR DESCRIPTION
## Summary
In the case of customers with hundreds of configs/monitors, importing all of the resources may take a long time. To prevent this and automate importing all of/a couple of resources, I have extended the importer functions of `edgedelta_config` and `edgedelta_monitor` to add the bulk importing feature, which works as follows:

The `terraform import` function accepts a resource name and an instance ID. With the new functionality, the instance ID can be one of

- A single resource ID in the UUID format

```bash
terraform import edgedelta_config.test_config 11111111-1111-1111-1111-111111111111
```

- Comma-separated resource ID values in the UUID format

```bash
terraform import edgedelta_config.test_configs 11111111-1111-1111-1111-111111111111,22222222-2222-2222-2222-222222222222
```

The command above creates two distinct `edgedelta_config` objects in the terraform state, `test_configs-1` and `test_configs-2`.

- A single star (`'*'`)

For importing every config or monitor resource available on the API to the terraform state.

```bash
terraform import edgedelta_monitor.test_monits "*"
```

The command above creates `N` distinct `edgedelta_monitor` objects in the terraform state which are named `test_monits-1`, `test_monits-2`, ..., `test_monits-N`.

## Testing

Simply create a bare minimum TF config file with an empty resource definition such as follows:

```hcl
terraform {
  required_providers {
    edgedelta = {
      source  = "edgedelta.com/local/edgedelta"
      version = "0.0.5"
    }
  }
}

variable "ED_API_TOKEN" {
  type = string
}

provider "edgedelta" {
  org_id             = "<FILL-HERE-BEFORE-RUNNING>"
  api_secret         = var.ED_API_TOKEN
}

output "instance_monitor_id" {
  value              = edgedelta_monitor.monits.id
  description        = "Monitor ID"
}

resource "edgedelta_monitor" "monits" {
  config_content     = ""
}
```

Then compile the provider on local by:

```bash
TERRAFORM_PROVIDER_ED_VERSION="0.0.5" TERRAFORM_PROVIDER_ED_OS_ARCH="<YOUR-ARCH-HERE>" make
```

> You can use `"darwin_amd64"` for MacOS and `"linux_arm64"` for Linux-based systems. You can also use `"${GOOS}_${GOARCH}"`.

Then, initialize and import:

```bash
terraform init
terraform import edgedelta_monitor.monits "*"
```

The last command will fetch all monitors registered to the organization (with `org_id`) and then save them to `terraform.tfstate`. You can then see the imported resources by using `terraform show`.