### PR TITLE
Version update for v0.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     edgedelta = {
       source  = "edgedelta/edgedelta"
-      version = "0.0.4"
+      version = "0.0.5"
     }
   }
 }

--- a/docs/terraform-provider-edgedelta.md
+++ b/docs/terraform-provider-edgedelta.md
@@ -214,7 +214,7 @@ terraform {
   required_providers {
     edgedelta = {
       source  = "edgedelta.com/local/edgedelta"
-      version = "0.0.4"   # If you've set TERRAFORM_PROVIDER_ED_VERSION=0.0.4
+      version = "0.0.5"   # If you've set TERRAFORM_PROVIDER_ED_VERSION=0.0.5
     }
   }
 }

--- a/examples/configs/bare_minimum/edgedelta.tf
+++ b/examples/configs/bare_minimum/edgedelta.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     edgedelta = {
       source  = "edgedelta/edgedelta"
-      version = "0.0.4"
+      version = "0.0.5"
     }
   }
 }

--- a/examples/configs/existing_configuration/edgedelta.tf
+++ b/examples/configs/existing_configuration/edgedelta.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     edgedelta = {
       source  = "edgedelta/edgedelta"
-      version = "0.0.4"
+      version = "0.0.5"
     }
   }
 }

--- a/examples/monitors/correlated-signal/main.tf
+++ b/examples/monitors/correlated-signal/main.tf
@@ -2,7 +2,7 @@ terraform {
     required_providers {
             edgedelta = {
             source  = "edgedelta/edgedelta"
-            version = "0.0.4"
+            version = "0.0.5"
         }
     }
 }

--- a/examples/monitors/metric-alert/main.tf
+++ b/examples/monitors/metric-alert/main.tf
@@ -2,7 +2,7 @@ terraform {
     required_providers {
             edgedelta = {
             source  = "edgedelta/edgedelta"
-            version = "0.0.4"
+            version = "0.0.5"
         }
     }
 }

--- a/examples/monitors/pattern-check/main.tf
+++ b/examples/monitors/pattern-check/main.tf
@@ -2,7 +2,7 @@ terraform {
     required_providers {
             edgedelta = {
             source  = "edgedelta/edgedelta"
-            version = "0.0.4"
+            version = "0.0.5"
         }
     }
 }

--- a/examples/monitors/pattern-skyline/main.tf
+++ b/examples/monitors/pattern-skyline/main.tf
@@ -2,7 +2,7 @@ terraform {
     required_providers {
             edgedelta = {
             source  = "edgedelta/edgedelta"
-            version = "0.0.4"
+            version = "0.0.5"
         }
     }
 }


### PR DESCRIPTION
## Summary

#6, #7 and #8 are not usable in the current Terraform provider version v0.0.4. This PR updates version numbers in various repo files to update the repo for the new release v0.0.5.