### PR TITLE
Update version to v0.0.6 - Darwin arm64 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     edgedelta = {
       source  = "edgedelta/edgedelta"
-      version = "0.0.5"
+      version = "0.0.6"
     }
   }
 }

--- a/docs/terraform-provider-edgedelta.md
+++ b/docs/terraform-provider-edgedelta.md
@@ -214,7 +214,7 @@ terraform {
   required_providers {
     edgedelta = {
       source  = "edgedelta.com/local/edgedelta"
-      version = "0.0.5"   # If you've set TERRAFORM_PROVIDER_ED_VERSION=0.0.5
+      version = "0.0.6"   # If you've set TERRAFORM_PROVIDER_ED_VERSION=0.0.6
     }
   }
 }

--- a/examples/configs/bare_minimum/edgedelta.tf
+++ b/examples/configs/bare_minimum/edgedelta.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     edgedelta = {
       source  = "edgedelta/edgedelta"
-      version = "0.0.5"
+      version = "0.0.6"
     }
   }
 }

--- a/examples/configs/existing_configuration/edgedelta.tf
+++ b/examples/configs/existing_configuration/edgedelta.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     edgedelta = {
       source  = "edgedelta/edgedelta"
-      version = "0.0.5"
+      version = "0.0.6"
     }
   }
 }

--- a/examples/monitors/correlated-signal/main.tf
+++ b/examples/monitors/correlated-signal/main.tf
@@ -2,7 +2,7 @@ terraform {
     required_providers {
             edgedelta = {
             source  = "edgedelta/edgedelta"
-            version = "0.0.5"
+            version = "0.0.6"
         }
     }
 }

--- a/examples/monitors/metric-alert/main.tf
+++ b/examples/monitors/metric-alert/main.tf
@@ -2,7 +2,7 @@ terraform {
     required_providers {
             edgedelta = {
             source  = "edgedelta/edgedelta"
-            version = "0.0.5"
+            version = "0.0.6"
         }
     }
 }

--- a/examples/monitors/pattern-check/main.tf
+++ b/examples/monitors/pattern-check/main.tf
@@ -2,7 +2,7 @@ terraform {
     required_providers {
             edgedelta = {
             source  = "edgedelta/edgedelta"
-            version = "0.0.5"
+            version = "0.0.6"
         }
     }
 }

--- a/examples/monitors/pattern-skyline/main.tf
+++ b/examples/monitors/pattern-skyline/main.tf
@@ -2,7 +2,7 @@ terraform {
     required_providers {
             edgedelta = {
             source  = "edgedelta/edgedelta"
-            version = "0.0.5"
+            version = "0.0.6"
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR updates the version number to v0.0.6 to change the version numbers in various TF files to the latest one before the release. This PR is just for the preparation of the next release, which is to build the missing Darwin arm64 build