### PR TITLE
Fix Hashicorp's failing ghaction-import-gpg action in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        uses: crazy-max/ghaction-import-gpg@v5.0.0
         env:
           # These secrets will need to be configured for the repository:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

This PR fixes the release workflow issue by changing the used gpg import action from hashicorp/ghaction-import-gpg@v2.1.0 to crazy-max/ghaction-import-gpg@v5.0.0