### PR TITLE
[VPB-6472] manage dashboards with terraform provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,23 @@ provider "edgedelta" {
 resource "edgedelta_config" "bare_minimum" {
   config_content     = file("/path/to/the/agent/configuration/file.yml")
 }
+
+# Dashboard example
+resource "edgedelta_dashboard" "monitoring" {
+  dashboard_name = "Infrastructure Monitoring"
+  description    = "Main monitoring dashboard"
+  tags           = ["infrastructure", "monitoring"]
+
+  definition = file("/path/to/dashboard.json")
+}
 ```
+
+## Available Resources
+
+| Resource | Description |
+|----------|-------------|
+| `edgedelta_config` | Manages agent configurations |
+| `edgedelta_dashboard` | Manages dashboards |
 
 Further [usage documentation is available in the provider repo](docs/index.md).
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -1,0 +1,78 @@
+# edgedelta_dashboard Resource
+
+Manages an EdgeDelta dashboard.
+
+## Example Usage
+
+### Basic Dashboard
+
+```hcl
+resource "edgedelta_dashboard" "monitoring" {
+  dashboard_name = "Infrastructure Monitoring"
+  description    = "Main monitoring dashboard for production infrastructure"
+  tags           = ["infrastructure", "monitoring", "production"]
+
+  definition = file("${path.module}/dashboards/monitoring.json")
+}
+```
+
+### Dashboard with Inline Definition
+
+```hcl
+resource "edgedelta_dashboard" "simple" {
+  dashboard_name = "Simple Dashboard"
+
+  definition = jsonencode({
+    panels = [
+      {
+        type  = "graph"
+        title = "Requests per Second"
+      }
+    ]
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+### Required
+
+* `dashboard_name` - (Required) Name of the dashboard.
+
+### Optional
+
+* `description` - (Optional) Description of the dashboard.
+* `tags` - (Optional) List of searchable tags for the dashboard.
+* `definition` - (Optional) Dashboard definition as a JSON string. Use `file()` to load from a file or `jsonencode()` for inline definitions. The provider will suppress diffs for semantically equivalent JSON.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `dashboard_id` - Unique identifier for the dashboard.
+* `creator` - User ID who created the dashboard.
+* `updater` - User ID who last updated the dashboard.
+* `created` - UTC timestamp of dashboard creation.
+* `updated` - UTC timestamp of last update.
+
+## Import
+
+Dashboards can be imported using the dashboard ID:
+
+```shell
+terraform import edgedelta_dashboard.example <dashboard_id>
+```
+
+Multiple dashboards can be imported using comma-separated IDs:
+
+```shell
+terraform import edgedelta_dashboard.example <id1>,<id2>,<id3>
+```
+
+All dashboards can be imported using `*`:
+
+```shell
+terraform import edgedelta_dashboard.example "*"
+```

--- a/edgedelta/api_client.go
+++ b/edgedelta/api_client.go
@@ -205,3 +205,80 @@ func (cli *APIClient) DeleteConfigWithID(configID string) error {
 	}
 	return nil
 }
+
+// Dashboard API methods
+
+// GetDashboard retrieves a single dashboard by ID
+func (cli *APIClient) GetDashboard(dashboardID string) (*GetDashboardResponse, error) {
+	if ok := validateUUID(dashboardID); !ok {
+		return nil, fmt.Errorf("failed to validate the dashboard ID: '%s'", dashboardID)
+	}
+	cli.initializeHTTPClient()
+	b, _, err := cli.doRequest("dashboards", dashboardID, http.MethodGet, true, true, nil)
+	if err != nil {
+		return nil, err
+	}
+	var responseData GetDashboardResponse
+	if err := json.Unmarshal(b, &responseData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the response body: %s", err)
+	}
+	return &responseData, nil
+}
+
+// GetAllDashboards retrieves all dashboards for the organization (used for import)
+func (cli *APIClient) GetAllDashboards() ([]*Dashboard, error) {
+	cli.initializeHTTPClient()
+	b, _, err := cli.doRequest("dashboards", "", http.MethodGet, true, true, nil)
+	if err != nil {
+		return nil, err
+	}
+	var responseData []*Dashboard
+	if err := json.Unmarshal(b, &responseData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the response body: %s", err)
+	}
+	return responseData, nil
+}
+
+// CreateDashboard creates a new dashboard
+func (cli *APIClient) CreateDashboard(dashboard *Dashboard) (*CreateDashboardResponse, error) {
+	cli.initializeHTTPClient()
+	b, _, err := cli.doRequest("dashboards", "", http.MethodPost, true, true, dashboard)
+	if err != nil {
+		return nil, err
+	}
+	var responseData CreateDashboardResponse
+	if err := json.Unmarshal(b, &responseData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the response body: %s", err)
+	}
+	return &responseData, nil
+}
+
+// UpdateDashboard updates an existing dashboard
+func (cli *APIClient) UpdateDashboard(dashboardID string, dashboard *Dashboard) (*UpdateDashboardResponse, error) {
+	if ok := validateUUID(dashboardID); !ok {
+		return nil, fmt.Errorf("failed to validate the dashboard ID: '%s'", dashboardID)
+	}
+	cli.initializeHTTPClient()
+	b, _, err := cli.doRequest("dashboards", dashboardID, http.MethodPut, true, true, dashboard)
+	if err != nil {
+		return nil, err
+	}
+	var responseData UpdateDashboardResponse
+	if err := json.Unmarshal(b, &responseData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the response body: %s", err)
+	}
+	return &responseData, nil
+}
+
+// DeleteDashboard deletes a dashboard by ID
+func (cli *APIClient) DeleteDashboard(dashboardID string) error {
+	if ok := validateUUID(dashboardID); !ok {
+		return fmt.Errorf("failed to validate the dashboard ID: '%s'", dashboardID)
+	}
+	cli.initializeHTTPClient()
+	_, _, err := cli.doRequest("dashboards", dashboardID, http.MethodDelete, true, false, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/edgedelta/api_client.go
+++ b/edgedelta/api_client.go
@@ -32,7 +32,7 @@ func (cli *APIClient) initializeHTTPClient() {
 	t.MaxIdleConnsPerHost = 1
 
 	cli.cl = &http.Client{
-		Timeout:   10 * time.Second,
+		Timeout:   60 * time.Second,
 		Transport: t,
 	}
 }

--- a/edgedelta/api_client_test.go
+++ b/edgedelta/api_client_test.go
@@ -259,7 +259,9 @@ func TestUpdateDashboard(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(expectedResponse)
+		if err := json.NewEncoder(w).Encode(expectedResponse); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
 	})
 	defer server.Close()
 
@@ -362,7 +364,9 @@ func TestGetConfigWithID_Mock(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(expectedConfig)
+		if err := json.NewEncoder(w).Encode(expectedConfig); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
 	})
 	defer server.Close()
 
@@ -402,7 +406,9 @@ func TestGetAllConfigs_Mock(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(expectedConfigs)
+		if err := json.NewEncoder(w).Encode(expectedConfigs); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
 	})
 	defer server.Close()
 
@@ -458,14 +464,15 @@ func TestDeleteConfigWithID_Mock(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{}`))
+		_, err := w.Write([]byte(`{}`))
+		if err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
 	})
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	err := client.DeleteConfigWithID(testConfigID)
-
-	if err != nil {
+	if err := client.DeleteConfigWithID(testConfigID); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/edgedelta/api_client_test.go
+++ b/edgedelta/api_client_test.go
@@ -71,7 +71,9 @@ func TestGetDashboard(t *testing.T) {
 
 		// Return mock response
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(expectedDashboard)
+		if err := json.NewEncoder(w).Encode(expectedDashboard); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
 	})
 	defer server.Close()
 
@@ -145,7 +147,9 @@ func TestGetAllDashboards(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(expectedDashboards)
+		if err := json.NewEncoder(w).Encode(expectedDashboards); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
 	})
 	defer server.Close()
 
@@ -217,7 +221,9 @@ func TestCreateDashboard(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(expectedResponse)
+		if err := json.NewEncoder(w).Encode(expectedResponse); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
 	})
 	defer server.Close()
 
@@ -442,7 +448,9 @@ func TestCreateConfig_Mock(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(expectedResponse)
+		if err := json.NewEncoder(w).Encode(expectedResponse); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
 	})
 	defer server.Close()
 

--- a/edgedelta/api_client_test.go
+++ b/edgedelta/api_client_test.go
@@ -1,8 +1,12 @@
 package edgedelta
 
 import (
+	"encoding/json"
 	"flag"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -14,22 +18,465 @@ var (
 	confPath    = flag.String("conf_path", "", "Path to the new config file")
 )
 
-func TestGetConfigWithID(t *testing.T) {
-	if *orgID == "" {
-		t.Error("org_id is not specified")
-		return
+// Test constants
+const (
+	testOrgID       = "test-org-123"
+	testAPISecret   = "test-api-secret"
+	testDashboardID = "550e8400-e29b-41d4-a716-446655440000"
+	testConfigID    = "660e8400-e29b-41d4-a716-446655440001"
+)
+
+// Helper function to create a mock server
+func newMockServer(handler http.HandlerFunc) *httptest.Server {
+	return httptest.NewServer(handler)
+}
+
+// Helper function to create an API client pointing to mock server
+func newTestClient(serverURL string) *APIClient {
+	return &APIClient{
+		OrgID:      testOrgID,
+		APIBaseURL: serverURL,
+		apiSecret:  testAPISecret,
 	}
-	if *apiKey == "" {
-		t.Error("api_key is not specified")
-		return
+}
+
+// =============================================================================
+// Dashboard API Unit Tests (Mock Server)
+// =============================================================================
+
+func TestGetDashboard(t *testing.T) {
+	expectedDashboard := Dashboard{
+		DashboardID:   testDashboardID,
+		DashboardName: "Test Dashboard",
+		Description:   "A test dashboard",
+		Tags:          []string{"test", "unit"},
+		Creator:       "user-123",
+		Updater:       "user-123",
+		Created:       "2024-01-01T00:00:00Z",
+		Updated:       "2024-01-02T00:00:00Z",
 	}
-	if *confID == "" {
-		t.Error("conf_id is not specified")
-		return
+
+	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET method, got %s", r.Method)
+		}
+		expectedPath := "/v1/orgs/" + testOrgID + "/dashboards/" + testDashboardID
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+		if r.Header.Get("X-ED-API-Token") != testAPISecret {
+			t.Errorf("expected API token header, got %s", r.Header.Get("X-ED-API-Token"))
+		}
+
+		// Return mock response
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expectedDashboard)
+	})
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetDashboard(testDashboardID)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if *apiEndpoint == "" {
-		t.Error("api_endpoint is not specified")
-		return
+	if result.DashboardID != expectedDashboard.DashboardID {
+		t.Errorf("expected dashboard ID %s, got %s", expectedDashboard.DashboardID, result.DashboardID)
+	}
+	if result.DashboardName != expectedDashboard.DashboardName {
+		t.Errorf("expected dashboard name %s, got %s", expectedDashboard.DashboardName, result.DashboardName)
+	}
+	if result.Description != expectedDashboard.Description {
+		t.Errorf("expected description %s, got %s", expectedDashboard.Description, result.Description)
+	}
+}
+
+func TestGetDashboard_InvalidID(t *testing.T) {
+	client := &APIClient{
+		OrgID:      testOrgID,
+		APIBaseURL: "http://localhost",
+		apiSecret:  testAPISecret,
+	}
+
+	_, err := client.GetDashboard("invalid-uuid")
+	if err == nil {
+		t.Error("expected error for invalid UUID, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to validate the dashboard ID") {
+		t.Errorf("expected UUID validation error, got: %v", err)
+	}
+}
+
+func TestGetDashboard_NotFound(t *testing.T) {
+	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error": "dashboard not found"}`))
+	})
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	_, err := client.GetDashboard(testDashboardID)
+
+	if err == nil {
+		t.Error("expected error for 404 response, got nil")
+	}
+}
+
+func TestGetAllDashboards(t *testing.T) {
+	expectedDashboards := []*Dashboard{
+		{
+			DashboardID:   "550e8400-e29b-41d4-a716-446655440001",
+			DashboardName: "Dashboard 1",
+		},
+		{
+			DashboardID:   "550e8400-e29b-41d4-a716-446655440002",
+			DashboardName: "Dashboard 2",
+		},
+	}
+
+	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET method, got %s", r.Method)
+		}
+		expectedPath := "/v1/orgs/" + testOrgID + "/dashboards"
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expectedDashboards)
+	})
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetAllDashboards()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Errorf("expected 2 dashboards, got %d", len(result))
+	}
+	if result[0].DashboardName != "Dashboard 1" {
+		t.Errorf("expected 'Dashboard 1', got %s", result[0].DashboardName)
+	}
+}
+
+func TestGetAllDashboards_Empty(t *testing.T) {
+	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[]`))
+	})
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetAllDashboards()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected 0 dashboards, got %d", len(result))
+	}
+}
+
+func TestCreateDashboard(t *testing.T) {
+	inputDashboard := &Dashboard{
+		DashboardName: "New Dashboard",
+		Description:   "Created via API",
+		Tags:          []string{"new", "test"},
+	}
+
+	expectedResponse := Dashboard{
+		DashboardID:   testDashboardID,
+		DashboardName: "New Dashboard",
+		Description:   "Created via API",
+		Tags:          []string{"new", "test"},
+		Creator:       "user-123",
+		Created:       "2024-01-01T00:00:00Z",
+	}
+
+	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST method, got %s", r.Method)
+		}
+		expectedPath := "/v1/orgs/" + testOrgID + "/dashboards"
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		// Verify request body
+		var receivedDashboard Dashboard
+		if err := json.NewDecoder(r.Body).Decode(&receivedDashboard); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		if receivedDashboard.DashboardName != inputDashboard.DashboardName {
+			t.Errorf("expected name %s, got %s", inputDashboard.DashboardName, receivedDashboard.DashboardName)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(expectedResponse)
+	})
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.CreateDashboard(inputDashboard)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.DashboardID != testDashboardID {
+		t.Errorf("expected dashboard ID %s, got %s", testDashboardID, result.DashboardID)
+	}
+	if result.DashboardName != inputDashboard.DashboardName {
+		t.Errorf("expected name %s, got %s", inputDashboard.DashboardName, result.DashboardName)
+	}
+}
+
+func TestUpdateDashboard(t *testing.T) {
+	inputDashboard := &Dashboard{
+		DashboardName: "Updated Dashboard",
+		Description:   "Updated description",
+	}
+
+	expectedResponse := Dashboard{
+		DashboardID:   testDashboardID,
+		DashboardName: "Updated Dashboard",
+		Description:   "Updated description",
+		Updater:       "user-456",
+		Updated:       "2024-01-03T00:00:00Z",
+	}
+
+	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT method, got %s", r.Method)
+		}
+		expectedPath := "/v1/orgs/" + testOrgID + "/dashboards/" + testDashboardID
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expectedResponse)
+	})
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.UpdateDashboard(testDashboardID, inputDashboard)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.DashboardName != inputDashboard.DashboardName {
+		t.Errorf("expected name %s, got %s", inputDashboard.DashboardName, result.DashboardName)
+	}
+	if result.Description != inputDashboard.Description {
+		t.Errorf("expected description %s, got %s", inputDashboard.Description, result.Description)
+	}
+}
+
+func TestUpdateDashboard_InvalidID(t *testing.T) {
+	client := &APIClient{
+		OrgID:      testOrgID,
+		APIBaseURL: "http://localhost",
+		apiSecret:  testAPISecret,
+	}
+
+	_, err := client.UpdateDashboard("invalid-uuid", &Dashboard{})
+	if err == nil {
+		t.Error("expected error for invalid UUID, got nil")
+	}
+}
+
+func TestDeleteDashboard(t *testing.T) {
+	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE method, got %s", r.Method)
+		}
+		expectedPath := "/v1/orgs/" + testOrgID + "/dashboards/" + testDashboardID
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	err := client.DeleteDashboard(testDashboardID)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteDashboard_InvalidID(t *testing.T) {
+	client := &APIClient{
+		OrgID:      testOrgID,
+		APIBaseURL: "http://localhost",
+		apiSecret:  testAPISecret,
+	}
+
+	err := client.DeleteDashboard("invalid-uuid")
+	if err == nil {
+		t.Error("expected error for invalid UUID, got nil")
+	}
+}
+
+func TestDeleteDashboard_NotFound(t *testing.T) {
+	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error": "dashboard not found"}`))
+	})
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	err := client.DeleteDashboard(testDashboardID)
+
+	if err == nil {
+		t.Error("expected error for 404 response, got nil")
+	}
+}
+
+// =============================================================================
+// Config API Unit Tests (Mock Server)
+// =============================================================================
+
+func TestGetConfigWithID_Mock(t *testing.T) {
+	expectedConfig := GetConfigResponse{
+		ID:          testConfigID,
+		Content:     "test: config",
+		Description: "Test config",
+		Tag:         "v1.0.0",
+	}
+
+	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET method, got %s", r.Method)
+		}
+		expectedPath := "/v1/orgs/" + testOrgID + "/confs/" + testConfigID
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expectedConfig)
+	})
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetConfigWithID(testConfigID)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ID != expectedConfig.ID {
+		t.Errorf("expected config ID %s, got %s", expectedConfig.ID, result.ID)
+	}
+}
+
+func TestGetConfigWithID_InvalidID(t *testing.T) {
+	client := &APIClient{
+		OrgID:      testOrgID,
+		APIBaseURL: "http://localhost",
+		apiSecret:  testAPISecret,
+	}
+
+	_, err := client.GetConfigWithID("invalid-uuid")
+	if err == nil {
+		t.Error("expected error for invalid UUID, got nil")
+	}
+}
+
+func TestGetAllConfigs_Mock(t *testing.T) {
+	expectedConfigs := []*Config{
+		{ID: "550e8400-e29b-41d4-a716-446655440001", Content: "config1"},
+		{ID: "550e8400-e29b-41d4-a716-446655440002", Content: "config2"},
+	}
+
+	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET method, got %s", r.Method)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expectedConfigs)
+	})
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetAllConfigs()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Errorf("expected 2 configs, got %d", len(result))
+	}
+}
+
+func TestCreateConfig_Mock(t *testing.T) {
+	inputConfig := Config{
+		Content:     "new: config",
+		Environment: KubernetesEnvironmentType,
+	}
+
+	expectedResponse := CreateConfigResponse{
+		ID:      testConfigID,
+		Content: "new: config",
+		Tag:     "v1.0.0",
+	}
+
+	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST method, got %s", r.Method)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(expectedResponse)
+	})
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.CreateConfig(inputConfig)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ID != testConfigID {
+		t.Errorf("expected config ID %s, got %s", testConfigID, result.ID)
+	}
+}
+
+func TestDeleteConfigWithID_Mock(t *testing.T) {
+	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE method, got %s", r.Method)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	err := client.DeleteConfigWithID(testConfigID)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// =============================================================================
+// Integration Tests (Require Real API - Skip if no credentials)
+// =============================================================================
+
+func TestGetConfigWithID_Integration(t *testing.T) {
+	if *orgID == "" || *apiKey == "" || *confID == "" || *apiEndpoint == "" {
+		t.Skip("Skipping integration test: missing required flags (org_id, api_key, conf_id, api_endpoint)")
 	}
 
 	cli := APIClient{
@@ -46,27 +493,15 @@ func TestGetConfigWithID(t *testing.T) {
 	t.Logf("%v", confObject)
 }
 
-func TestUpdateConfigWithID(t *testing.T) {
-	if *orgID == "" {
-		t.Error("org_id is not specified")
-		return
-	}
-	if *confID == "" {
-		t.Error("conf_id is not specified")
-		return
-	}
-	if *confPath == "" {
-		t.Error("conf_path is not specified")
-		return
-	}
-	if *apiEndpoint == "" {
-		t.Error("api_endpoint is not specified")
-		return
+func TestUpdateConfigWithID_Integration(t *testing.T) {
+	if *orgID == "" || *confID == "" || *confPath == "" || *apiEndpoint == "" || *apiKey == "" {
+		t.Skip("Skipping integration test: missing required flags")
 	}
 
 	cli := APIClient{
 		OrgID:      *orgID,
 		APIBaseURL: *apiEndpoint,
+		apiSecret:  *apiKey,
 	}
 
 	confDataRaw, err := os.ReadFile(*confPath)
@@ -88,22 +523,9 @@ func TestUpdateConfigWithID(t *testing.T) {
 	t.Logf("%v", confObject)
 }
 
-func TestCreateConfigWithID(t *testing.T) {
-	if *orgID == "" {
-		t.Error("org_id is not specified")
-		return
-	}
-	if *confPath == "" {
-		t.Error("conf_path is not specified")
-		return
-	}
-	if *apiKey == "" {
-		t.Error("api_key is not specified")
-		return
-	}
-	if *apiEndpoint == "" {
-		t.Error("api_endpoint is not specified")
-		return
+func TestCreateConfig_Integration(t *testing.T) {
+	if *orgID == "" || *confPath == "" || *apiKey == "" || *apiEndpoint == "" {
+		t.Skip("Skipping integration test: missing required flags")
 	}
 
 	cli := APIClient{

--- a/edgedelta/api_client_test.go
+++ b/edgedelta/api_client_test.go
@@ -71,7 +71,7 @@ func TestGetDashboard(t *testing.T) {
 
 		// Return mock response
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(expectedDashboard)
+		_ = json.NewEncoder(w).Encode(expectedDashboard)
 	})
 	defer server.Close()
 
@@ -111,7 +111,7 @@ func TestGetDashboard_InvalidID(t *testing.T) {
 func TestGetDashboard_NotFound(t *testing.T) {
 	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`{"error": "dashboard not found"}`))
+		_, _ = w.Write([]byte(`{"error": "dashboard not found"}`))
 	})
 	defer server.Close()
 
@@ -145,7 +145,7 @@ func TestGetAllDashboards(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(expectedDashboards)
+		_ = json.NewEncoder(w).Encode(expectedDashboards)
 	})
 	defer server.Close()
 
@@ -166,7 +166,7 @@ func TestGetAllDashboards(t *testing.T) {
 func TestGetAllDashboards_Empty(t *testing.T) {
 	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`[]`))
+		_, _ = w.Write([]byte(`[]`))
 	})
 	defer server.Close()
 
@@ -217,7 +217,7 @@ func TestCreateDashboard(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(expectedResponse)
+		_ = json.NewEncoder(w).Encode(expectedResponse)
 	})
 	defer server.Close()
 
@@ -328,7 +328,7 @@ func TestDeleteDashboard_InvalidID(t *testing.T) {
 func TestDeleteDashboard_NotFound(t *testing.T) {
 	server := newMockServer(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`{"error": "dashboard not found"}`))
+		_, _ = w.Write([]byte(`{"error": "dashboard not found"}`))
 	})
 	defer server.Close()
 

--- a/edgedelta/provider.go
+++ b/edgedelta/provider.go
@@ -31,7 +31,8 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"edgedelta_config": resourceConfig(),
+			"edgedelta_config":    resourceConfig(),
+			"edgedelta_dashboard": resourceDashboard(),
 		},
 		DataSourcesMap:       map[string]*schema.Resource{},
 		ConfigureContextFunc: providerConfigure,

--- a/edgedelta/resources_dashboard.go
+++ b/edgedelta/resources_dashboard.go
@@ -1,0 +1,373 @@
+package edgedelta
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceDashboard() *schema.Resource {
+	return &schema.Resource{
+		SchemaVersion: 1,
+		CreateContext: resourceDashboardCreate,
+		ReadContext:   resourceDashboardRead,
+		UpdateContext: resourceDashboardUpdate,
+		DeleteContext: resourceDashboardDelete,
+		Description:   "Manages an EdgeDelta dashboard resource.",
+		Schema: map[string]*schema.Schema{
+			// Required
+			"dashboard_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the dashboard.",
+			},
+
+			// Optional
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Description of the dashboard.",
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Searchable tags for the dashboard.",
+			},
+			"definition": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: suppressEquivalentJSON,
+				ValidateFunc:     validateJSON,
+				Description:      "Dashboard definition as a JSON string. Use file() or jsonencode() to provide the value.",
+			},
+
+			// Computed
+			"dashboard_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Unique identifier for the dashboard.",
+			},
+			"creator": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "User ID who created the dashboard.",
+			},
+			"updater": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "User ID who last updated the dashboard.",
+			},
+			"created": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "UTC timestamp of dashboard creation.",
+			},
+			"updated": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "UTC timestamp of last update.",
+			},
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+				meta := m.(*ProviderMetadata)
+				dashboardID := d.Id()
+				if dashboardID == "" {
+					return nil, fmt.Errorf("could not determine the resource ID - possibly the ID was not set")
+				}
+
+				// Support importing all dashboards with "*"
+				if dashboardID == "*" {
+					dashboards, err := meta.client.GetAllDashboards()
+					if err != nil {
+						return nil, fmt.Errorf("could not get dashboards from API: %s", err)
+					}
+					results := make([]*schema.ResourceData, 0, len(dashboards))
+					for _, dash := range dashboards {
+						dd := resourceDashboard().Data(nil)
+						dd.SetId(dash.DashboardID)
+						if err := setDashboardState(dd, dash); err != nil {
+							return nil, fmt.Errorf("failed to set dashboard state: %s", err)
+						}
+						results = append(results, dd)
+					}
+					return results, nil
+				}
+
+				// Support comma-separated IDs
+				var dashboardIDs []string
+				if strings.Contains(dashboardID, ",") {
+					dashboardIDs = strings.Split(dashboardID, ",")
+				} else {
+					dashboardIDs = []string{dashboardID}
+				}
+
+				results := make([]*schema.ResourceData, 0, len(dashboardIDs))
+				for _, id := range dashboardIDs {
+					id = strings.TrimSpace(id)
+					dd := resourceDashboard().Data(nil)
+					resp, err := meta.client.GetDashboard(id)
+					if err != nil {
+						return nil, fmt.Errorf("could not get dashboard from API: %s (dashboard ID was: '%s')", err, id)
+					}
+					dd.SetId(resp.DashboardID)
+					dashboard := Dashboard(*resp)
+					if err := setDashboardState(dd, &dashboard); err != nil {
+						return nil, fmt.Errorf("failed to set dashboard state: %s", err)
+					}
+					results = append(results, dd)
+				}
+				return results, nil
+			},
+		},
+	}
+}
+
+type dashboardArgs struct {
+	dashboardName string
+	description   string
+	tags          []string
+	definition    map[string]interface{}
+	diags         diag.Diagnostics
+}
+
+func parseDashboardArgs(d *schema.ResourceData) *dashboardArgs {
+	args := &dashboardArgs{}
+
+	// Required field
+	if v, ok := d.GetOk("dashboard_name"); ok {
+		args.dashboardName = v.(string)
+	} else {
+		args.diags = append(args.diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "dashboard_name is required",
+		})
+	}
+
+	// Optional fields
+	if v, ok := d.GetOk("description"); ok {
+		args.description = v.(string)
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		args.tags = interfaceSliceToStringSlice(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("definition"); ok {
+		defStr := v.(string)
+		if defStr != "" {
+			def, err := stringToJSONMap(defStr)
+			if err != nil {
+				args.diags = append(args.diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Invalid definition JSON",
+					Detail:   err.Error(),
+				})
+			} else {
+				args.definition = def
+			}
+		}
+	}
+
+	return args
+}
+
+func setDashboardState(d *schema.ResourceData, dash *Dashboard) error {
+	if err := d.Set("dashboard_id", dash.DashboardID); err != nil {
+		return err
+	}
+	if err := d.Set("dashboard_name", dash.DashboardName); err != nil {
+		return err
+	}
+	if err := d.Set("description", dash.Description); err != nil {
+		return err
+	}
+	if len(dash.Tags) > 0 {
+		if err := d.Set("tags", stringSliceToInterface(dash.Tags)); err != nil {
+			return err
+		}
+	}
+	if dash.Definition != nil {
+		defStr, err := jsonMapToString(dash.Definition)
+		if err != nil {
+			return err
+		}
+		if err := d.Set("definition", defStr); err != nil {
+			return err
+		}
+	}
+	if err := d.Set("creator", dash.Creator); err != nil {
+		return err
+	}
+	if err := d.Set("updater", dash.Updater); err != nil {
+		return err
+	}
+	if err := d.Set("created", dash.Created); err != nil {
+		return err
+	}
+	if err := d.Set("updated", dash.Updated); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceDashboardCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	meta := m.(*ProviderMetadata)
+	args := parseDashboardArgs(d)
+	if len(args.diags) > 0 {
+		return args.diags
+	}
+
+	dashboard := &Dashboard{
+		DashboardName: args.dashboardName,
+		Description:   args.description,
+		Tags:          args.tags,
+		Definition:    args.definition,
+	}
+
+	resp, err := meta.client.CreateDashboard(dashboard)
+	if err != nil {
+		args.diags = append(args.diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Could not create the dashboard resource",
+			Detail:   err.Error(),
+		})
+		return args.diags
+	}
+
+	d.SetId(resp.DashboardID)
+	dashResp := Dashboard(*resp)
+	if err := setDashboardState(d, &dashResp); err != nil {
+		args.diags = append(args.diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Failed to set dashboard state after create",
+			Detail:   err.Error(),
+		})
+	}
+
+	return args.diags
+}
+
+func resourceDashboardRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	meta := m.(*ProviderMetadata)
+	var diags diag.Diagnostics
+
+	dashboardID := d.Id()
+	if dashboardID == "" {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Cannot determine dashboard ID",
+			Detail:   "Dashboard ID is required but not found in Terraform state",
+		})
+		return diags
+	}
+
+	resp, err := meta.client.GetDashboard(dashboardID)
+	if err != nil {
+		// Check if resource was deleted outside Terraform
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+			d.SetId("")
+			return diags
+		}
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Could not read the dashboard resource",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	dashResp := Dashboard(*resp)
+	if err := setDashboardState(d, &dashResp); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Failed to set dashboard state after read",
+			Detail:   err.Error(),
+		})
+	}
+
+	return diags
+}
+
+func resourceDashboardUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	meta := m.(*ProviderMetadata)
+	args := parseDashboardArgs(d)
+	if len(args.diags) > 0 {
+		return args.diags
+	}
+
+	dashboardID := d.Id()
+	if dashboardID == "" {
+		args.diags = append(args.diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Cannot determine dashboard ID for update",
+			Detail:   "Dashboard ID is required but not found in Terraform state",
+		})
+		return args.diags
+	}
+
+	dashboard := &Dashboard{
+		DashboardName: args.dashboardName,
+		Description:   args.description,
+		Tags:          args.tags,
+		Definition:    args.definition,
+	}
+
+	resp, err := meta.client.UpdateDashboard(dashboardID, dashboard)
+	if err != nil {
+		args.diags = append(args.diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Could not update the dashboard resource",
+			Detail:   err.Error(),
+		})
+		return args.diags
+	}
+
+	dashResp := Dashboard(*resp)
+	if err := setDashboardState(d, &dashResp); err != nil {
+		args.diags = append(args.diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Failed to set dashboard state after update",
+			Detail:   err.Error(),
+		})
+	}
+
+	return args.diags
+}
+
+func resourceDashboardDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	meta := m.(*ProviderMetadata)
+	var diags diag.Diagnostics
+
+	dashboardID := d.Id()
+	if dashboardID == "" {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Cannot determine dashboard ID for deletion",
+			Detail:   "Dashboard ID is required but not found in Terraform state",
+		})
+		return diags
+	}
+
+	err := meta.client.DeleteDashboard(dashboardID)
+	if err != nil {
+		// If already deleted, just remove from state
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+			d.SetId("")
+			return diags
+		}
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Could not delete the dashboard resource",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	d.SetId("")
+	return diags
+}

--- a/edgedelta/types.go
+++ b/edgedelta/types.go
@@ -68,16 +68,18 @@ type ConfigHistory struct {
 
 // Dashboard represents an EdgeDelta dashboard
 type Dashboard struct {
-	OrgID         string                 `json:"org_id,omitempty"`
-	DashboardID   string                 `json:"dashboard_id,omitempty"`
-	DashboardName string                 `json:"dashboard_name"`
-	Description   string                 `json:"description,omitempty"`
-	Tags          []string               `json:"tags,omitempty"`
-	Creator       string                 `json:"creator,omitempty"`
-	Updater       string                 `json:"updater,omitempty"`
-	Created       string                 `json:"created,omitempty"`
-	Updated       string                 `json:"updated,omitempty"`
-	Definition    map[string]interface{} `json:"definition,omitempty"`
+	OrgID                   string                   `json:"org_id,omitempty"`
+	DashboardID             string                   `json:"dashboard_id,omitempty"`
+	DashboardName           string                   `json:"dashboard_name"`
+	Description             string                   `json:"description,omitempty"`
+	Tags                    []string                 `json:"tags,omitempty"`
+	Creator                 string                   `json:"creator,omitempty"`
+	Updater                 string                   `json:"updater,omitempty"`
+	Created                 string                   `json:"created,omitempty"`
+	Updated                 string                   `json:"updated,omitempty"`
+	Definition              map[string]interface{}   `json:"definition,omitempty"`
+	ResourceAccesses        []map[string]interface{} `json:"resource_accesses,omitempty"`
+	SharingSecuritySettings map[string]interface{}   `json:"sharing_security_settings,omitempty"`
 }
 
 // Dashboard API response types

--- a/edgedelta/types.go
+++ b/edgedelta/types.go
@@ -65,3 +65,22 @@ type ConfigHistory struct {
 	Content   string `json:"content"`
 	Status    string `json:"status"`
 }
+
+// Dashboard represents an EdgeDelta dashboard
+type Dashboard struct {
+	OrgID         string                 `json:"org_id,omitempty"`
+	DashboardID   string                 `json:"dashboard_id,omitempty"`
+	DashboardName string                 `json:"dashboard_name"`
+	Description   string                 `json:"description,omitempty"`
+	Tags          []string               `json:"tags,omitempty"`
+	Creator       string                 `json:"creator,omitempty"`
+	Updater       string                 `json:"updater,omitempty"`
+	Created       string                 `json:"created,omitempty"`
+	Updated       string                 `json:"updated,omitempty"`
+	Definition    map[string]interface{} `json:"definition,omitempty"`
+}
+
+// Dashboard API response types
+type GetDashboardResponse Dashboard
+type CreateDashboardResponse Dashboard
+type UpdateDashboardResponse Dashboard

--- a/edgedelta/validators.go
+++ b/edgedelta/validators.go
@@ -89,31 +89,3 @@ func stringToJSONMap(s string) (map[string]interface{}, error) {
 	}
 	return result, nil
 }
-
-// stringToJSONArray converts a JSON string to []map[string]interface{}
-func stringToJSONArray(s string) ([]map[string]interface{}, error) {
-	if s == "" {
-		return nil, nil
-	}
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return nil, nil
-	}
-	var result []map[string]interface{}
-	if err := json.Unmarshal([]byte(s), &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal JSON array: %v", err)
-	}
-	return result, nil
-}
-
-// jsonArrayToString converts a []map[string]interface{} to a JSON string
-func jsonArrayToString(arr []map[string]interface{}) (string, error) {
-	if arr == nil {
-		return "", nil
-	}
-	b, err := json.Marshal(arr)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal array to JSON: %v", err)
-	}
-	return string(b), nil
-}

--- a/edgedelta/validators.go
+++ b/edgedelta/validators.go
@@ -89,3 +89,31 @@ func stringToJSONMap(s string) (map[string]interface{}, error) {
 	}
 	return result, nil
 }
+
+// stringToJSONArray converts a JSON string to []map[string]interface{}
+func stringToJSONArray(s string) ([]map[string]interface{}, error) {
+	if s == "" {
+		return nil, nil
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	var result []map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON array: %v", err)
+	}
+	return result, nil
+}
+
+// jsonArrayToString converts a []map[string]interface{} to a JSON string
+func jsonArrayToString(arr []map[string]interface{}) (string, error) {
+	if arr == nil {
+		return "", nil
+	}
+	b, err := json.Marshal(arr)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal array to JSON: %v", err)
+	}
+	return string(b), nil
+}

--- a/edgedelta/validators.go
+++ b/edgedelta/validators.go
@@ -1,0 +1,91 @@
+package edgedelta
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// validateJSON validates that a string is valid JSON
+func validateJSON(val interface{}, key string) (warns []string, errs []error) {
+	v := val.(string)
+	if v == "" {
+		return nil, nil
+	}
+	var js interface{}
+	if err := json.Unmarshal([]byte(v), &js); err != nil {
+		errs = append(errs, fmt.Errorf("%q must be valid JSON, got: %s, error: %v", key, v, err))
+	}
+	return warns, errs
+}
+
+// suppressEquivalentJSON is a DiffSuppressFunc that suppresses diffs for equivalent JSON
+func suppressEquivalentJSON(k, old, new string, d *schema.ResourceData) bool {
+	if old == "" && new == "" {
+		return true
+	}
+	if old == "" || new == "" {
+		return false
+	}
+
+	var oldJSON, newJSON interface{}
+	if err := json.Unmarshal([]byte(old), &oldJSON); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(new), &newJSON); err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldJSON, newJSON)
+}
+
+// stringSliceToInterface converts a []string to []interface{} for Terraform state
+func stringSliceToInterface(s []string) []interface{} {
+	result := make([]interface{}, len(s))
+	for i, v := range s {
+		result[i] = v
+	}
+	return result
+}
+
+// interfaceSliceToStringSlice converts []interface{} from Terraform state to []string
+func interfaceSliceToStringSlice(s []interface{}) []string {
+	result := make([]string, len(s))
+	for i, v := range s {
+		if v != nil {
+			result[i] = v.(string)
+		}
+	}
+	return result
+}
+
+// jsonMapToString converts a map[string]interface{} to a JSON string
+func jsonMapToString(m map[string]interface{}) (string, error) {
+	if m == nil {
+		return "", nil
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal definition to JSON: %v", err)
+	}
+	return string(b), nil
+}
+
+// stringToJSONMap converts a JSON string to map[string]interface{}
+func stringToJSONMap(s string) (map[string]interface{}, error) {
+	if s == "" {
+		return nil, nil
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON: %v", err)
+	}
+	return result, nil
+}

--- a/examples/dashboards/bare_minimum/edgedelta.tf
+++ b/examples/dashboards/bare_minimum/edgedelta.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    edgedelta = {
+      source  = "edgedelta/edgedelta"
+      version = "0.0.9"
+    }
+  }
+}
+
+variable "ED_API_TOKEN" {
+  type = string
+}
+
+provider "edgedelta" {
+  org_id     = "<your-organization-id>"
+  api_secret = var.ED_API_TOKEN
+}
+
+output "dashboard_id" {
+  value       = edgedelta_dashboard.bare_minimum.dashboard_id
+  description = "The dashboard ID of the edgedelta_dashboard instance"
+}
+
+output "dashboard_name" {
+  value       = edgedelta_dashboard.bare_minimum.dashboard_name
+  description = "The name of the edgedelta_dashboard instance"
+}
+
+resource "edgedelta_dashboard" "bare_minimum" {
+  dashboard_name = "My Dashboard"
+  description    = "A simple dashboard created via Terraform"
+  tags           = ["terraform", "example"]
+
+  definition = file("/path/to/the/dashboard/definition/file.json")
+}

--- a/examples/dashboards/existing_dashboard/edgedelta.tf
+++ b/examples/dashboards/existing_dashboard/edgedelta.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    edgedelta = {
+      source  = "edgedelta/edgedelta"
+      version = "0.0.9"
+    }
+  }
+}
+
+variable "ED_API_TOKEN" {
+  type = string
+}
+
+provider "edgedelta" {
+  org_id     = "<your-organization-id>"
+  api_secret = var.ED_API_TOKEN
+}
+
+output "dashboard_id" {
+  value       = edgedelta_dashboard.existing.dashboard_id
+  description = "The dashboard ID of the edgedelta_dashboard instance"
+}
+
+output "dashboard_name" {
+  value       = edgedelta_dashboard.existing.dashboard_name
+  description = "The name of the edgedelta_dashboard instance"
+}
+
+# Import an existing dashboard using: terraform import edgedelta_dashboard.existing <dashboard-id>
+resource "edgedelta_dashboard" "existing" {
+  dashboard_name = "My Existing Dashboard"
+  description    = "An existing dashboard managed via Terraform"
+  tags           = ["terraform", "imported"]
+
+  definition = file("/path/to/the/dashboard/definition/file.json")
+}


### PR DESCRIPTION
## Summary

This PR adds managing dashboards

## Testing

- edgedelta/api_client.go
```
o test -timeout 30s -coverprofile=/var/folders/1b/btdy697d3p594zdfm3brfd0m0000gq/T/vscode-gomf4UuW/go-code-cover terraform-provider-edgedelta/edgedelta

ok  	terraform-provider-edgedelta/edgedelta	0.576s
```

### e2e tests
Used this request payload for testing

<details>
<summary>Request payload</summary>

```
{
  "dashboard_name": "veysi WAF Dashboard 2",
  "description": "API Web Application Firewall Stats",
  "tags": ["WAF", "Test", "aws", "veysi", "test"],
  "definition": {
    "version": 4,
    "timeFilters": {
      "lookback": "3h"
    },
    "variables": [
      {
        "id": 1,
        "key": "waf_logs_tag",
        "label": "WAF Logs Tag",
        "type": "facet-option",
        "value": "ed-dev-waf-logs",
        "params": {
          "allowEmpty": false,
          "allowMultiple": false,
          "autoSelect": true,
          "facet": "ed.tag",
          "scope": "log"
        }
      },
      {
        "id": 2,
        "key": "acl_id",
        "label": "ACL Id",
        "type": "facet-option",
        "value": [],
        "params": {
          "allowEmpty": false,
          "allowMultiple": true,
          "autoSelect": false,
          "facet": "@webaclId",
          "scope": "log"
        }
      }
    ],
    "widgets": [
      {
        "id": "root",
        "type": "grid",
        "grid": "72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px / 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr",
        "displayOptions": {
          "hideBackground": true
        }
      },
      {
        "id": 11,
        "type": "tabs",
        "items": [
          {"label": "Details"},
          {"label": "Map"}
        ],
        "position": {
          "type": "grid",
          "targetId": "root",
          "area": {
            "row": 1,
            "rowSpan": 20,
            "column": 1,
            "columnSpan": 12
          }
        },
        "displayOptions": {
          "hideBackground": true
        }
      },
      {
        "id": 55,
        "type": "grid",
        "grid": "72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px / 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr",
        "position": {
          "type": "tab",
          "targetId": 11,
          "index": 0
        },
        "displayOptions": {
          "hideBackground": true
        }
      },
      {
        "id": 1,
        "type": "viz",
        "resultType": "aggregate",
        "position": {
          "type": "grid",
          "targetId": 55,
          "area": {
            "row": 5,
            "rowSpan": 4,
            "column": 1,
            "columnSpan": 6
          }
        },
        "displayOptions": {
          "title": "Top Blocked IPs"
        },
        "visualizer": {
          "type": "table",
          "coloring": {
            "mode": "categorical"
          }
        },
        "visuals": [
          {
            "id": "A",
            "dataSource": {
              "type": "log",
              "params": {
                "query": "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.clientIp}"
              }
            }
          }
        ]
      },
      {
        "id": 2,
        "type": "viz",
        "resultType": "aggregate",
        "position": {
          "type": "grid",
          "targetId": 55,
          "area": {
            "row": 1,
            "rowSpan": 4,
            "column": 5,
            "columnSpan": 3
          }
        },
        "displayOptions": {
          "title": "Blocked Requests"
        },
        "visualizer": {
          "type": "bignumber"
        },
        "visuals": [
          {
            "id": "A",
            "dataSource": {
              "type": "log",
              "params": {
                "query": "{ed.tag:\"$waf_logs_tag\" @action:BLOCK @webaclId:\"$acl_id\"}"
              }
            }
          }
        ]
      },
      {
        "id": 3,
        "type": "viz",
        "resultType": "aggregate",
        "position": {
          "type": "grid",
          "targetId": 55,
          "area": {
            "row": 5,
            "rowSpan": 4,
            "column": 7,
            "columnSpan": 6
          }
        },
        "displayOptions": {
          "title": "Top Destinations for Blocked Traffic"
        },
        "visualizer": {
          "type": "table"
        },
        "visuals": [
          {
            "id": "A",
            "dataSource": {
              "type": "log",
              "params": {
                "query": "count_unique():{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.uri}"
              }
            }
          }
        ]
      },
      {
        "id": 4,
        "type": "viz",
        "resultType": "aggregate",
        "position": {
          "type": "grid",
          "targetId": 55,
          "area": {
            "row": 1,
            "rowSpan": 4,
            "column": 8,
            "columnSpan": 5
          }
        },
        "displayOptions": {
          "title": "Block Rules"
        },
        "visualizer": {
          "type": "table"
        },
        "visuals": [
          {
            "id": "A",
            "dataSource": {
              "type": "log",
              "params": {
                "query": "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@terminatingRuleId}"
              }
            }
          }
        ]
      },
      {
        "id": 5,
        "type": "viz",
        "resultType": "timeseries",
        "position": {
          "type": "grid",
          "targetId": 55,
          "area": {
            "row": 9,
            "rowSpan": 5,
            "column": 1,
            "columnSpan": 6
          }
        },
        "displayOptions": {
          "title": "Blocked Requests by IP"
        },
        "visualizer": {
          "type": "line"
        },
        "visuals": [
          {
            "id": "A",
            "dataSource": {
              "type": "log",
              "params": {
                "query": "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.clientIp}"
              }
            }
          }
        ]
      },
      {
        "id": 9,
        "type": "viz",
        "resultType": "aggregate",
        "position": {
          "type": "grid",
          "targetId": 55,
          "area": {
            "row": 9,
            "rowSpan": 5,
            "column": 7,
            "columnSpan": 6
          }
        },
        "displayOptions": {
          "title": "Blocked Requests by Country",
          "description": ""
        },
        "visualizer": {
          "type": "table"
        },
        "visuals": [
          {
            "id": "A",
            "dataSource": {
              "type": "log",
              "params": {
                "query": "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.country}"
              }
            }
          }
        ]
      },
      {
        "id": 10,
        "type": "markdown",
        "position": {
          "type": "grid",
          "targetId": 55,
          "area": {
            "row": 2,
            "rowSpan": 3,
            "column": 1,
            "columnSpan": 4
          }
        },
        "params": {
          "content": "## Security Resources\n\n- **[API WAF Rules](https://go/waf)**  \n  *Configuration for API-focused WAF rules to protect against threats like SQL injection and XSS.*\n\n- **[IP Block List](https://go/iplist)**  \n  *List of blocked IPs known for suspicious or malicious activity.*\n\n- **[AWS Managed WAF Rule Descriptions](https://go/wafdesc)**  \n  *Detailed overview of AWS-provided WAF rules for common vulnerabilities.*\n\n"
        },
        "displayOptions": {
          "hideBackground": true
        }
      },
      {
        "id": 56,
        "type": "viz",
        "resultType": "aggregate",
        "position": {
          "type": "grid",
          "targetId": 57,
          "area": {
            "row": 1,
            "rowSpan": 3,
            "column": 2,
            "columnSpan": 5
          }
        },
        "displayOptions": {
          "title": "",
          "hideExplorerLink": true
        },
        "visualizer": {
          "type": "geomap",
          "coloring": {
            "mode": "continuous",
            "max": 10,
            "palette": ["var(--semantic_accent-yellow)", "var(--semantic_accent-red)"]
          }
        },
        "visuals": [
          {
            "id": "A",
            "dataSource": {
              "type": "log",
              "params": {
                "query": "{ed.tag:\"$waf_logs_tag\" @action:BLOCK} by {@httpRequest.country}"
              }
            }
          }
        ]
      },
      {
        "id": 57,
        "type": "grid",
        "grid": "1fr 1fr 1fr 1fr 1fr 1fr / 1fr 1fr 1fr 1fr 1fr 1fr",
        "position": {
          "type": "tab",
          "targetId": 11,
          "index": 1
        },
        "displayOptions": {
          "hideBackground": true
        }
      },
      {
        "id": 58,
        "type": "viz",
        "resultType": "aggregate",
        "position": {
          "type": "grid",
          "targetId": 57,
          "area": {
            "row": 1,
            "rowSpan": 3,
            "column": 1,
            "columnSpan": 1
          }
        },
        "displayOptions": {
          "title": "",
          "hideExplorerLink": true
        },
        "visualizer": {
          "type": "list",
          "coloring": {
            "mode": "continuous",
            "max": 10,
            "palette": ["var(--semantic_accent-yellow)", "var(--semantic_accent-red)"]
          }
        },
        "visuals": [
          {
            "id": "A",
            "dataSource": {
              "type": "log",
              "params": {
                "query": "{ed.tag:\"$waf_logs_tag\" @action:BLOCK} by {@httpRequest.country}"
              }
            }
          }
        ]
      },
      {
        "id": 59,
        "type": "variable-control",
        "variableId": 2,
        "position": {
          "type": "grid",
          "targetId": 55,
          "area": {
            "row": 1,
            "rowSpan": 1,
            "column": 1,
            "columnSpan": 4
          }
        },
        "displayOptions": {
          "hideBackground": true
        }
      }
    ]
  },
  "sharing_security_settings": {},
  "resource_accesses": [
    {"domain": "log", "query": "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.clientIp}"},
    {"domain": "log", "query": "{ed.tag:\"$waf_logs_tag\" @action:BLOCK @webaclId:\"$acl_id\"}"},
    {"domain": "log", "query": "count_unique():{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.uri}"},
    {"domain": "log", "query": "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@terminatingRuleId}"},
    {"domain": "log", "query": "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.clientIp}"},
    {"domain": "log", "query": "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.country}"},
    {"domain": "log", "query": "{ed.tag:\"$waf_logs_tag\" @action:BLOCK} by {@httpRequest.country}"},
    {"domain": "log", "query": "{ed.tag:\"$waf_logs_tag\" @action:BLOCK} by {@httpRequest.country}"},
    {"domain": "facet_option", "facet_path": "ed.tag", "scope": "log"},
    {"domain": "facet_option", "facet_path": "@webaclId", "scope": "log"}
  ]
}
```

</details>


1. Build Provider & Setup

```
go build -o terraform-provider-edgedelta

echo 'provider_installation {
    dev_overrides {
      "edgedelta/edgedelta" = "/Users/mustafasoyvural/workspace/gocode/src/github.com/edgedelta/terraform-provider-edgedelta"
    }
    direct {}
  }' > ~/.terraformrc
```

2. Create the Dashboard
```
terraform plan
```

<details>
 <summary>terraform plan output</summary>

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  + create

Terraform will perform the following actions:

  # edgedelta_dashboard.waf_dashboard will be created
  + resource "edgedelta_dashboard" "waf_dashboard" {
      + created        = (known after apply)
      + creator        = (known after apply)
      + dashboard_id   = (known after apply)
      + dashboard_name = "Terraform WAF Dashboard"
      + definition     = jsonencode(
            {
              + dashboard_name            = "veysi WAF Dashboard 2"
              + definition                = {
                  + timeFilters = {
                      + lookback = "3h"
                    }
                  + variables   = [
                      + {
                          + id     = 1
                          + key    = "waf_logs_tag"
                          + label  = "WAF Logs Tag"
                          + params = {
                              + allowEmpty    = false
                              + allowMultiple = false
                              + autoSelect    = true
                              + facet         = "ed.tag"
                              + scope         = "log"
                            }
                          + type   = "facet-option"
                          + value  = "ed-dev-waf-logs"
                        },
                      + {
                          + id     = 2
                          + key    = "acl_id"
                          + label  = "ACL Id"
                          + params = {
                              + allowEmpty    = false
                              + allowMultiple = true
                              + autoSelect    = false
                              + facet         = "@webaclId"
                              + scope         = "log"
                            }
                          + type   = "facet-option"
                          + value  = []
                        },
                    ]
                  + version     = 4
                  + widgets     = [
                      + {
                          + displayOptions = {
                              + hideBackground = true
                            }
                          + grid           = "72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px / 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr"
                          + id             = "root"
                          + type           = "grid"
                        },
                      + {
                          + displayOptions = {
                              + hideBackground = true
                            }
                          + id             = 11
                          + items          = [
                              + {
                                  + label = "Details"
                                },
                              + {
                                  + label = "Map"
                                },
                            ]
                          + position       = {
                              + area     = {
                                  + column     = 1
                                  + columnSpan = 12
                                  + row        = 1
                                  + rowSpan    = 20
                                }
                              + targetId = "root"
                              + type     = "grid"
                            }
                          + type           = "tabs"
                        },
                      + {
                          + displayOptions = {
                              + hideBackground = true
                            }
                          + grid           = "72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px 72px / 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr"
                          + id             = 55
                          + position       = {
                              + index    = 0
                              + targetId = 11
                              + type     = "tab"
                            }
                          + type           = "grid"
                        },
                      + {
                          + displayOptions = {
                              + title = "Top Blocked IPs"
                            }
                          + id             = 1
                          + position       = {
                              + area     = {
                                  + column     = 1
                                  + columnSpan = 6
                                  + row        = 5
                                  + rowSpan    = 4
                                }
                              + targetId = 55
                              + type     = "grid"
                            }
                          + resultType     = "aggregate"
                          + type           = "viz"
                          + visualizer     = {
                              + coloring = {
                                  + mode = "categorical"
                                }
                              + type     = "table"
                            }
                          + visuals        = [
                              + {
                                  + dataSource = {
                                      + params = {
                                          + query = "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.clientIp}"
                                        }
                                      + type   = "log"
                                    }
                                  + id         = "A"
                                },
                            ]
                        },
                      + {
                          + displayOptions = {
                              + title = "Blocked Requests"
                            }
                          + id             = 2
                          + position       = {
                              + area     = {
                                  + column     = 5
                                  + columnSpan = 3
                                  + row        = 1
                                  + rowSpan    = 4
                                }
                              + targetId = 55
                              + type     = "grid"
                            }
                          + resultType     = "aggregate"
                          + type           = "viz"
                          + visualizer     = {
                              + type = "bignumber"
                            }
                          + visuals        = [
                              + {
                                  + dataSource = {
                                      + params = {
                                          + query = "{ed.tag:\"$waf_logs_tag\" @action:BLOCK @webaclId:\"$acl_id\"}"
                                        }
                                      + type   = "log"
                                    }
                                  + id         = "A"
                                },
                            ]
                        },
                      + {
                          + displayOptions = {
                              + title = "Top Destinations for Blocked Traffic"
                            }
                          + id             = 3
                          + position       = {
                              + area     = {
                                  + column     = 7
                                  + columnSpan = 6
                                  + row        = 5
                                  + rowSpan    = 4
                                }
                              + targetId = 55
                              + type     = "grid"
                            }
                          + resultType     = "aggregate"
                          + type           = "viz"
                          + visualizer     = {
                              + type = "table"
                            }
                          + visuals        = [
                              + {
                                  + dataSource = {
                                      + params = {
                                          + query = "count_unique():{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.uri}"
                                        }
                                      + type   = "log"
                                    }
                                  + id         = "A"
                                },
                            ]
                        },
                      + {
                          + displayOptions = {
                              + title = "Block Rules"
                            }
                          + id             = 4
                          + position       = {
                              + area     = {
                                  + column     = 8
                                  + columnSpan = 5
                                  + row        = 1
                                  + rowSpan    = 4
                                }
                              + targetId = 55
                              + type     = "grid"
                            }
                          + resultType     = "aggregate"
                          + type           = "viz"
                          + visualizer     = {
                              + type = "table"
                            }
                          + visuals        = [
                              + {
                                  + dataSource = {
                                      + params = {
                                          + query = "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@terminatingRuleId}"
                                        }
                                      + type   = "log"
                                    }
                                  + id         = "A"
                                },
                            ]
                        },
                      + {
                          + displayOptions = {
                              + title = "Blocked Requests by IP"
                            }
                          + id             = 5
                          + position       = {
                              + area     = {
                                  + column     = 1
                                  + columnSpan = 6
                                  + row        = 9
                                  + rowSpan    = 5
                                }
                              + targetId = 55
                              + type     = "grid"
                            }
                          + resultType     = "timeseries"
                          + type           = "viz"
                          + visualizer     = {
                              + type = "line"
                            }
                          + visuals        = [
                              + {
                                  + dataSource = {
                                      + params = {
                                          + query = "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.clientIp}"
                                        }
                                      + type   = "log"
                                    }
                                  + id         = "A"
                                },
                            ]
                        },
                      + {
                          + displayOptions = {
                              + description = ""
                              + title       = "Blocked Requests by Country"
                            }
                          + id             = 9
                          + position       = {
                              + area     = {
                                  + column     = 7
                                  + columnSpan = 6
                                  + row        = 9
                                  + rowSpan    = 5
                                }
                              + targetId = 55
                              + type     = "grid"
                            }
                          + resultType     = "aggregate"
                          + type           = "viz"
                          + visualizer     = {
                              + type = "table"
                            }
                          + visuals        = [
                              + {
                                  + dataSource = {
                                      + params = {
                                          + query = "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.country}"
                                        }
                                      + type   = "log"
                                    }
                                  + id         = "A"
                                },
                            ]
                        },
                      + {
                          + displayOptions = {
                              + hideBackground = true
                            }
                          + id             = 10
                          + params         = {
                              + content = <<-EOT
                                    ## Security Resources

                                    - **[API WAF Rules](https://go/waf)**
                                      *Configuration for API-focused WAF rules to protect against threats like SQL injection and XSS.*

                                    - **[IP Block List](https://go/iplist)**
                                      *List of blocked IPs known for suspicious or malicious activity.*

                                    - **[AWS Managed WAF Rule Descriptions](https://go/wafdesc)**
                                      *Detailed overview of AWS-provided WAF rules for common vulnerabilities.*
                                EOT
                            }
                          + position       = {
                              + area     = {
                                  + column     = 1
                                  + columnSpan = 4
                                  + row        = 2
                                  + rowSpan    = 3
                                }
                              + targetId = 55
                              + type     = "grid"
                            }
                          + type           = "markdown"
                        },
                      + {
                          + displayOptions = {
                              + hideExplorerLink = true
                              + title            = ""
                            }
                          + id             = 56
                          + position       = {
                              + area     = {
                                  + column     = 2
                                  + columnSpan = 5
                                  + row        = 1
                                  + rowSpan    = 3
                                }
                              + targetId = 57
                              + type     = "grid"
                            }
                          + resultType     = "aggregate"
                          + type           = "viz"
                          + visualizer     = {
                              + coloring = {
                                  + max     = 10
                                  + mode    = "continuous"
                                  + palette = [
                                      + "var(--semantic_accent-yellow)",
                                      + "var(--semantic_accent-red)",
                                    ]
                                }
                              + type     = "geomap"
                            }
                          + visuals        = [
                              + {
                                  + dataSource = {
                                      + params = {
                                          + query = "{ed.tag:\"$waf_logs_tag\" @action:BLOCK} by {@httpRequest.country}"
                                        }
                                      + type   = "log"
                                    }
                                  + id         = "A"
                                },
                            ]
                        },
                      + {
                          + displayOptions = {
                              + hideBackground = true
                            }
                          + grid           = "1fr 1fr 1fr 1fr 1fr 1fr / 1fr 1fr 1fr 1fr 1fr 1fr"
                          + id             = 57
                          + position       = {
                              + index    = 1
                              + targetId = 11
                              + type     = "tab"
                            }
                          + type           = "grid"
                        },
                      + {
                          + displayOptions = {
                              + hideExplorerLink = true
                              + title            = ""
                            }
                          + id             = 58
                          + position       = {
                              + area     = {
                                  + column     = 1
                                  + columnSpan = 1
                                  + row        = 1
                                  + rowSpan    = 3
                                }
                              + targetId = 57
                              + type     = "grid"
                            }
                          + resultType     = "aggregate"
                          + type           = "viz"
                          + visualizer     = {
                              + coloring = {
                                  + max     = 10
                                  + mode    = "continuous"
                                  + palette = [
                                      + "var(--semantic_accent-yellow)",
                                      + "var(--semantic_accent-red)",
                                    ]
                                }
                              + type     = "list"
                            }
                          + visuals        = [
                              + {
                                  + dataSource = {
                                      + params = {
                                          + query = "{ed.tag:\"$waf_logs_tag\" @action:BLOCK} by {@httpRequest.country}"
                                        }
                                      + type   = "log"
                                    }
                                  + id         = "A"
                                },
                            ]
                        },
                      + {
                          + displayOptions = {
                              + hideBackground = true
                            }
                          + id             = 59
                          + position       = {
                              + area     = {
                                  + column     = 1
                                  + columnSpan = 4
                                  + row        = 1
                                  + rowSpan    = 1
                                }
                              + targetId = 55
                              + type     = "grid"
                            }
                          + type           = "variable-control"
                          + variableId     = 2
                        },
                    ]
                }
              + description               = "API Web Application Firewall Stats"
              + resource_accesses         = [
                  + {
                      + domain = "log"
                      + query  = "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.clientIp}"
                    },
                  + {
                      + domain = "log"
                      + query  = "{ed.tag:\"$waf_logs_tag\" @action:BLOCK @webaclId:\"$acl_id\"}"
                    },
                  + {
                      + domain = "log"
                      + query  = "count_unique():{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.uri}"
                    },
                  + {
                      + domain = "log"
                      + query  = "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@terminatingRuleId}"
                    },
                  + {
                      + domain = "log"
                      + query  = "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.clientIp}"
                    },
                  + {
                      + domain = "log"
                      + query  = "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.country}"
                    },
                  + {
                      + domain = "log"
                      + query  = "{ed.tag:\"$waf_logs_tag\" @action:BLOCK} by {@httpRequest.country}"
                    },
                  + {
                      + domain = "log"
                      + query  = "{ed.tag:\"$waf_logs_tag\" @action:BLOCK} by {@httpRequest.country}"
                    },
                  + {
                      + domain     = "facet_option"
                      + facet_path = "ed.tag"
                      + scope      = "log"
                    },
                  + {
                      + domain     = "facet_option"
                      + facet_path = "@webaclId"
                      + scope      = "log"
                    },
                ]
              + sharing_security_settings = {}
              + tags                      = [
                  + "WAF",
                  + "Test",
                  + "aws",
                  + "veysi",
                  + "test",
                ]
            }
        )
      + description    = "API Web Application Firewall Stats"
      + id             = (known after apply)
      + tags           = [
          + "WAF",
          + "Test",
          + "aws",
          + "terraform",
          + "veysi",
        ]
      + updated        = (known after apply)
      + updater        = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + dashboard_created = (known after apply)
  + dashboard_id      = (known after apply)
  + dashboard_name    = "Terraform WAF Dashboard"
  + dashboard_updated = (known after apply)
```

</details>


```
terraform apply -auto-approve
```

```
Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + dashboard_created = (known after apply)
  + dashboard_id      = (known after apply)
  + dashboard_name    = "Terraform WAF Dashboard"
  + dashboard_updated = (known after apply)
edgedelta_dashboard.waf_dashboard: Creating...
edgedelta_dashboard.waf_dashboard: Creation complete after 2s [id=b72cf187-0c71-4a6b-b978-28ed05de132e]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

dashboard_created = "2025-12-12 11:07:47.450713 +0000 UTC"
dashboard_id = "b72cf187-0c71-4a6b-b978-28ed05de132e"
dashboard_name = "Terraform WAF Dashboard"
dashboard_updated = "2025-12-12 11:07:47.450713 +0000 UTC"
```

Screenshots from admin web ui

<img width="1461" height="549" alt="Screenshot 2025-12-12 at 14 09 17" src="https://github.com/user-attachments/assets/f482f433-1dc2-4134-b09a-7936b0b361e9" />


<img width="1466" height="913" alt="Screenshot 2025-12-12 at 14 09 41" src="https://github.com/user-attachments/assets/69ed110f-405e-48e9-be8c-1d88d65eec69" />


#### Update the dashboard

  - Block Rules (id 4): column 5, columnSpan 3 (left side)
  - Blocked Requests (id 2): column 8, columnSpan 5 (right side)

```
terraform plan
```

<details>
<summary>terraform plan output</summary>

```
edgedelta_dashboard.waf_dashboard: Refreshing state... [id=b72cf187-0c71-4a6b-b978-28ed05de132e]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # edgedelta_dashboard.waf_dashboard will be updated in-place
  ~ resource "edgedelta_dashboard" "waf_dashboard" {
      ~ definition     = jsonencode(
          ~ {
              + dashboard_name            = "veysi WAF Dashboard 2"
              ~ definition                = {
                  ~ widgets     = [
                        # (3 unchanged elements hidden)
                        {
                            displayOptions = {
                                title = "Top Blocked IPs"
                            }
                            id             = 1
                            position       = {
                                area     = {
                                    column     = 1
                                    columnSpan = 6
                                    row        = 5
                                    rowSpan    = 4
                                }
                                targetId = 55
                                type     = "grid"
                            }
                            resultType     = "aggregate"
                            type           = "viz"
                            visualizer     = {
                                coloring = {
                                    mode = "categorical"
                                }
                                type     = "table"
                            }
                            visuals        = [
                                {
                                    dataSource = {
                                        params = {
                                            query = "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.clientIp}"
                                        }
                                        type   = "log"
                                    }
                                    id         = "A"
                                },
                            ]
                        },
                      ~ {
                            id             = 2
                          ~ position       = {
                              ~ area     = {
                                  ~ column     = 5 -> 8
                                  ~ columnSpan = 3 -> 5
                                    # (2 unchanged attributes hidden)
                                }
                                # (2 unchanged attributes hidden)
                            }
                            # (5 unchanged attributes hidden)
                        },
                        {
                            displayOptions = {
                                title = "Top Destinations for Blocked Traffic"
                            }
                            id             = 3
                            position       = {
                                area     = {
                                    column     = 7
                                    columnSpan = 6
                                    row        = 5
                                    rowSpan    = 4
                                }
                                targetId = 55
                                type     = "grid"
                            }
                            resultType     = "aggregate"
                            type           = "viz"
                            visualizer     = {
                                type = "table"
                            }
                            visuals        = [
                                {
                                    dataSource = {
                                        params = {
                                            query = "count_unique():{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.uri}"
                                        }
                                        type   = "log"
                                    }
                                    id         = "A"
                                },
                            ]
                        },
                      ~ {
                            id             = 4
                          ~ position       = {
                              ~ area     = {
                                  ~ column     = 8 -> 5
                                  ~ columnSpan = 5 -> 3
                                    # (2 unchanged attributes hidden)
                                }
                                # (2 unchanged attributes hidden)
                            }
                            # (5 unchanged attributes hidden)
                        },
                        {
                            displayOptions = {
                                title = "Blocked Requests by IP"
                            }
                            id             = 5
                            position       = {
                                area     = {
                                    column     = 1
                                    columnSpan = 6
                                    row        = 9
                                    rowSpan    = 5
                                }
                                targetId = 55
                                type     = "grid"
                            }
                            resultType     = "timeseries"
                            type           = "viz"
                            visualizer     = {
                                type = "line"
                            }
                            visuals        = [
                                {
                                    dataSource = {
                                        params = {
                                            query = "{ed.tag:\"$waf_logs_tag\" @action:\"BLOCK\" @webaclId:\"$acl_id\"} by {@httpRequest.clientIp}"
                                        }
                                        type   = "log"
                                    }
                                    id         = "A"
                                },
                            ]
                        },
                        # (6 unchanged elements hidden)
                    ]
                    # (3 unchanged attributes hidden)
                }
              + description               = "API Web Application Firewall Stats"
              + tags                      = [
                  + "WAF",
                  + "Test",
                  + "aws",
                  + "veysi",
                  + "test",
                ]
                # (2 unchanged attributes hidden)
            }
        )
        id             = "b72cf187-0c71-4a6b-b978-28ed05de132e"
        tags           = [
            "WAF",
            "Test",
            "aws",
            "terraform",
            "veysi",
        ]
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

</details>


```
terraform apply -auto-approve
```

```
Plan: 0 to add, 1 to change, 0 to destroy.
edgedelta_dashboard.waf_dashboard: Modifying... [id=b72cf187-0c71-4a6b-b978-28ed05de132e]
edgedelta_dashboard.waf_dashboard: Modifications complete after 1s [id=b72cf187-0c71-4a6b-b978-28ed05de132e]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

dashboard_created = "2025-12-12 11:07:47.450713 +0000 UTC"
dashboard_id = "b72cf187-0c71-4a6b-b978-28ed05de132e"
dashboard_name = "Terraform WAF Dashboard"
dashboard_updated = "2025-12-12 11:07:47.450713 +0000 UTC"
```

<img width="1464" height="916" alt="Screenshot 2025-12-12 at 14 27 32" src="https://github.com/user-attachments/assets/ab6b2dd2-7581-42f3-9c97-f2eb8719e526" />



#### remove dashboard

```
Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  - dashboard_created = "2025-12-12 11:07:47.450713 +0000 UTC" -> null
  - dashboard_id      = "b72cf187-0c71-4a6b-b978-28ed05de132e" -> null
  - dashboard_name    = "Terraform WAF Dashboard" -> null
  - dashboard_updated = "2025-12-12 11:25:26.934567 +0000 UTC" -> null
edgedelta_dashboard.waf_dashboard: Destroying... [id=b72cf187-0c71-4a6b-b978-28ed05de132e]
edgedelta_dashboard.waf_dashboard: Destruction complete after 1s

Destroy complete! Resources: 1 destroyed.
```

<img width="1469" height="580" alt="Screenshot 2025-12-12 at 14 29 11" src="https://github.com/user-attachments/assets/69c57328-c346-4e71-855d-e80ce3cbd509" />

